### PR TITLE
修复设置空数组给 weui-picker 组件，点击确定报错，页面自动刷新。

### DIFF
--- a/src/picker/picker.component.ts
+++ b/src/picker/picker.component.ts
@@ -79,7 +79,7 @@ export class PickerComponent implements ControlValueAccessor, OnDestroy, OnChang
     @Input() disabled: boolean = false;
     /**
      * 确认后回调当前选择数据（包括已选面板所有数据）
-     * 
+     *
      * `{ value: '10000', items: [ {}, {}, {} ] }`
      */
     @Output() change = new EventEmitter<any>();
@@ -133,7 +133,9 @@ export class PickerComponent implements ControlValueAccessor, OnDestroy, OnChang
         let res: any[] = [];
         this._groups.forEach((items: PickerData[], idx: number) => {
             const item = items[this._selected[idx]];
-            res.push(item);
+            if (item) {
+                res.push(item);
+            }
         });
         return res;
     }


### PR DESCRIPTION
这个情况发生在给 weui-picker 设置的数据为“空数组”的时候，点击组件再点击确认，会导致代码报错然后页面自动刷新。
### 修改的代码如下：
![image](https://user-images.githubusercontent.com/14272789/30000178-faab2c24-9094-11e7-849d-504904d34a2a.png)
### 下面是 gif 演示：
![](http://g.recordit.co/BOncLtLhVX.gif)
